### PR TITLE
Support grace period in AsyncValueSource

### DIFF
--- a/Bsii.Dotnet.Utils.Tests/AsyncUtilsTest.cs
+++ b/Bsii.Dotnet.Utils.Tests/AsyncUtilsTest.cs
@@ -203,8 +203,7 @@ namespace Bsii.Dotnet.Utils.Tests
             var value2 = new object();
             asyncValueSource.SetNext(value2);
             // we should be able to continue since because the next value was set since we were watching
-            var (n1, n2, n3) = await AsyncUtils.ResolveAll(getNext1, getNext2, getNext3)
-                .TimeoutAfter(TimeSpan.FromSeconds(1));
+            var (n1, n2, n3) = await AsyncUtils.ResolveAll(getNext1, getNext2, getNext3);
             n1.Should().Be(value2);
             n2.Should().Be(value2);
             n3.Should().Be(value2);
@@ -215,8 +214,7 @@ namespace Bsii.Dotnet.Utils.Tests
             getNext2 = asyncValueProvider.GetNextAsync();
             getNext3 = asyncValueProvider.GetNextAsync();
             // now don't wait => waiters should resolve instantly even though we didn't pass next value
-            (n1, n2, n3) = await AsyncUtils.ResolveAll(getNext1, getNext2, getNext3)
-                .TimeoutAfter(TimeSpan.FromSeconds(1));
+            (n1, n2, n3) = await AsyncUtils.ResolveAll(getNext1, getNext2, getNext3);
             n1.Should().Be(value3);
             n2.Should().Be(value3);
             n3.Should().Be(value3);

--- a/Bsii.Dotnet.Utils.Tests/AsyncUtilsTest.cs
+++ b/Bsii.Dotnet.Utils.Tests/AsyncUtilsTest.cs
@@ -257,7 +257,7 @@ namespace Bsii.Dotnet.Utils.Tests
         [Fact]
         public async Task TestAsyncValueSourceWithLatestValue()
         {
-            AsyncValueSource<object> asyncValueSource = new(TimeSpan.Zero);
+            AsyncValueSource<object> asyncValueSource = new(Timeout.InfiniteTimeSpan);
             IAsyncValueProvider<object> asyncValueProvider = asyncValueSource;
 
             // no graceful value provision
@@ -275,6 +275,21 @@ namespace Bsii.Dotnet.Utils.Tests
 
             // no new value provided, but we always get the latest one
             getNext1.Should().Be(getNext2);
+        }
+
+        [Fact]
+        public void TestAsyncValueSourceWithInvalidGrace()
+        {
+            // these are illegal
+            Assert.Throws<ArgumentException>(
+                () => new AsyncValueSource<bool>(TimeSpan.Zero));
+
+            Assert.Throws<ArgumentException>(
+                () => new AsyncValueSource<bool>(TimeSpan.FromSeconds(-1)));
+
+            // these are legal
+            _ = new AsyncValueSource<bool>(TimeSpan.FromSeconds(1));
+            _ = new AsyncValueSource<bool>(Timeout.InfiniteTimeSpan);
         }
     }
 }

--- a/Bsii.Dotnet.Utils/AsyncEventSource.cs
+++ b/Bsii.Dotnet.Utils/AsyncEventSource.cs
@@ -10,6 +10,10 @@ namespace Bsii.Dotnet.Utils
     {
         private readonly AsyncValueSource<bool> _signaler;
 
+        /// <summary>
+        /// </summary>
+        /// <param name="gracePeriod">If positive, latest value will be provided to awaiters for so long since received.
+        /// Otherwise, latest available value will be provided without waiting.</param>
         public AsyncEventSource(TimeSpan? gracePeriod = default)
             => _signaler = new AsyncValueSource<bool>(gracePeriod);
 

--- a/Bsii.Dotnet.Utils/AsyncEventSource.cs
+++ b/Bsii.Dotnet.Utils/AsyncEventSource.cs
@@ -12,7 +12,7 @@ namespace Bsii.Dotnet.Utils
 
         /// <summary>
         /// </summary>
-        /// <param name="gracePeriod">If positive, latest value will be provided to awaiters for so long since received.
+        /// <param name="gracePeriod">If positive, will signal new awaiters for so long since received.
         /// Otherwise, latest available value will be provided without waiting.</param>
         public AsyncEventSource(TimeSpan? gracePeriod = default)
             => _signaler = new AsyncValueSource<bool>(gracePeriod);

--- a/Bsii.Dotnet.Utils/AsyncEventSource.cs
+++ b/Bsii.Dotnet.Utils/AsyncEventSource.cs
@@ -12,8 +12,9 @@ namespace Bsii.Dotnet.Utils
 
         /// <summary>
         /// </summary>
-        /// <param name="gracePeriod">If positive, will signal new awaiters for so long since received.
-        /// Otherwise, latest available value will be provided without waiting.</param>
+        /// <param name="gracePeriod">If null, will block awaiters until next signal,</br>
+        /// If positive, will return to awaiters if latest signal was set for so long since received,</br>
+        /// If value is <see cref="System.Threading.Timeout.InfiniteTimeSpan">, will return without waiting (unless no signal was set).</param>
         public AsyncEventSource(TimeSpan? gracePeriod = default)
             => _signaler = new AsyncValueSource<bool>(gracePeriod);
 

--- a/Bsii.Dotnet.Utils/AsyncEventSource.cs
+++ b/Bsii.Dotnet.Utils/AsyncEventSource.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 
 namespace Bsii.Dotnet.Utils
 {
@@ -7,8 +8,10 @@ namespace Bsii.Dotnet.Utils
     /// </summary>
     public class AsyncEventSource
     {
-        private readonly AsyncValueSource<bool> _signaler = 
-            new AsyncValueSource<bool>();
+        private readonly AsyncValueSource<bool> _signaler;
+
+        public AsyncEventSource(TimeSpan? gracePeriod = default)
+            => _signaler = new AsyncValueSource<bool>(gracePeriod);
 
         /// <summary>
         /// Sends a signal to current awaiters

--- a/Bsii.Dotnet.Utils/AsyncEventSource.cs
+++ b/Bsii.Dotnet.Utils/AsyncEventSource.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace Bsii.Dotnet.Utils
 {
@@ -8,15 +7,8 @@ namespace Bsii.Dotnet.Utils
     /// </summary>
     public class AsyncEventSource
     {
-        private readonly AsyncValueSource<bool> _signaler;
-
-        /// <summary>
-        /// </summary>
-        /// <param name="gracePeriod">If null, will block awaiters until next signal,</br>
-        /// If positive, will return to awaiters if latest signal was set for so long since received,</br>
-        /// If value is <see cref="System.Threading.Timeout.InfiniteTimeSpan">, will return without waiting (unless no signal was set).</param>
-        public AsyncEventSource(TimeSpan? gracePeriod = default)
-            => _signaler = new AsyncValueSource<bool>(gracePeriod);
+        private readonly AsyncValueSource<bool> _signaler =
+            new AsyncValueSource<bool>();
 
         /// <summary>
         /// Sends a signal to current awaiters
@@ -26,6 +18,6 @@ namespace Bsii.Dotnet.Utils
         /// <summary>
         /// Waits for a future signal
         /// </summary>
-        public Task WaitAsync() => _signaler.GetNextAsync();
+        public Task WaitAsync() => _signaler.GetLatestWithGraceOrNextAsync();
     }
 }

--- a/Bsii.Dotnet.Utils/AsyncValueSource.cs
+++ b/Bsii.Dotnet.Utils/AsyncValueSource.cs
@@ -30,8 +30,9 @@ namespace Bsii.Dotnet.Utils
 
         /// <summary>
         /// </summary>
-        /// <param name="gracePeriod">If null, will block awaiters until next value provided,</br>If positive, latest value will be provided to awaiters for so long since received,</br>
-        /// If value is <see cref="System.Threading.Timeout.Infinite">, latest available value will be provided without waiting (unless no latest value available).</param>
+        /// <param name="gracePeriod">If null, will block awaiters until next value provided,</br>
+        /// If positive, latest value will be provided to awaiters for so long since received,</br>
+        /// If value is <see cref="System.Threading.Timeout.InfiniteTimeSpan"/>, latest available value will be provided without waiting (unless no latest value available).</param>
         public AsyncValueSource(TimeSpan? gracePeriod = default)
             => _gracePeriod = gracePeriod;
 

--- a/Bsii.Dotnet.Utils/AsyncValueSource.cs
+++ b/Bsii.Dotnet.Utils/AsyncValueSource.cs
@@ -4,33 +4,61 @@ using System.Threading.Tasks;
 namespace Bsii.Dotnet.Utils
 {
     /// <summary>
-    /// Provides <typeparamref name="T"/> values to all asynchrnously awaiting consumers<br/>
+    /// Provides <typeparamref name="T"/> values to all asynchronously awaiting consumers<br/>
     /// Note: all awaiters will get a reference to the same values (in case that <typeparamref name="T"/> is reference type)
     /// </summary>
     public class AsyncValueSource<T> : IAsyncValueProvider<T>
     {
-        private TaskCompletionSource<T> _captured;
-        private DateTime _captureTime;
+        private class AsyncValue<TValue>
+        {
+            public TaskCompletionSource<TValue> TaskCompletionSource { get; }
+            public DateTime ValueTime { get; }
+
+            public AsyncValue(TaskCompletionSource<TValue> taskCompletionSource, DateTime valueTime)
+            {
+                TaskCompletionSource = taskCompletionSource;
+                ValueTime = valueTime;
+            }
+        }
+
+        private AsyncValue<T> _captured;
 
         private TaskCompletionSource<T> _tcs = new TaskCompletionSource<T>(
             TaskCreationOptions.RunContinuationsAsynchronously);
 
-        private readonly TimeSpan _gracePeriod;
+        private readonly TimeSpan? _gracePeriod;
 
+        /// <summary>
+        /// </summary>
+        /// <param name="gracePeriod">If positive, latest value will be provided to awaiters for so long since received.
+        /// Otherwise, latest available value will be provided without waiting.</param>
         public AsyncValueSource(TimeSpan? gracePeriod = default)
-            => _gracePeriod = gracePeriod ?? TimeSpan.Zero;
+            => _gracePeriod = gracePeriod;
 
         public void SetNext(T value)
         {
-            (_captured, _captureTime) = (_tcs, DateTime.UtcNow);
+            _captured = new AsyncValue<T>(_tcs, DateTime.UtcNow);
             _tcs = new TaskCompletionSource<T>(
                 TaskCreationOptions.RunContinuationsAsynchronously);
-            _captured.SetResult(value);
+            _captured.TaskCompletionSource.SetResult(value);
         }
 
         public Task<T> GetNextAsync()
-            => _captureTime + _gracePeriod < DateTime.UtcNow
-                ? _tcs.Task
-                : _captured.Task;
+        {
+            if (_gracePeriod.HasValue)
+            {
+                if (_gracePeriod <= TimeSpan.Zero ||
+                    _captured?.ValueTime + _gracePeriod.Value > DateTime.UtcNow)
+                {
+                    return _captured?.TaskCompletionSource.Task ?? _tcs.Task;
+                }
+                else
+                {
+                    _captured = default;
+                }
+            }
+
+            return _tcs.Task;
+        }
     }
 }

--- a/Bsii.Dotnet.Utils/AsyncValueSource.cs
+++ b/Bsii.Dotnet.Utils/AsyncValueSource.cs
@@ -30,8 +30,8 @@ namespace Bsii.Dotnet.Utils
 
         /// <summary>
         /// </summary>
-        /// <param name="gracePeriod">If positive, latest value will be provided to awaiters for so long since received.
-        /// Otherwise, latest available value will be provided without waiting.</param>
+        /// <param name="gracePeriod">If null, will block awaiters until next value provided,</br>If positive, latest value will be provided to awaiters for so long since received,</br>
+        /// If value is <see cref="System.Threading.Timeout.Infinite">, latest available value will be provided without waiting (unless no latest value available).</param>
         public AsyncValueSource(TimeSpan? gracePeriod = default)
             => _gracePeriod = gracePeriod;
 

--- a/Bsii.Dotnet.Utils/AsyncValueSource.cs
+++ b/Bsii.Dotnet.Utils/AsyncValueSource.cs
@@ -45,7 +45,7 @@ namespace Bsii.Dotnet.Utils
 
         public Task<T> GetNextAsync()
         {
-            if (_gracePeriod.HasValue)
+            if (_gracePeriod.HasValue && _captured != default)
             {
                 if (_gracePeriod <= TimeSpan.Zero ||
                     _captured?.ValueTime + _gracePeriod.Value > DateTime.UtcNow)

--- a/Bsii.Dotnet.Utils/AsyncValueSource.cs
+++ b/Bsii.Dotnet.Utils/AsyncValueSource.cs
@@ -1,75 +1,24 @@
-﻿using System;
-using System.Threading;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace Bsii.Dotnet.Utils
 {
     /// <summary>
-    /// Provides <typeparamref name="T"/> values to all asynchronously awaiting consumers<br/>
+    /// Provides <typeparamref name="T"/> values to all asynchrnously awaiting consumers<br/>
     /// Note: all awaiters will get a reference to the same values (in case that <typeparamref name="T"/> is reference type)
     /// </summary>
     public class AsyncValueSource<T> : IAsyncValueProvider<T>
     {
-        private class AsyncValue<TValue>
-        {
-            public TaskCompletionSource<TValue> TaskCompletionSource { get; }
-            public DateTime ValueTime { get; }
-
-            public AsyncValue(TaskCompletionSource<TValue> taskCompletionSource, DateTime valueTime)
-            {
-                TaskCompletionSource = taskCompletionSource;
-                ValueTime = valueTime;
-            }
-        }
-
-        private AsyncValue<T> _captured;
-
         private TaskCompletionSource<T> _tcs = new TaskCompletionSource<T>(
             TaskCreationOptions.RunContinuationsAsynchronously);
 
-        private readonly TimeSpan? _gracePeriod;
-
-        /// <summary>
-        /// </summary>
-        /// <param name="gracePeriod">If null, will block awaiters until next value provided,</br>
-        /// If positive, latest value will be provided to awaiters for so long since received,</br>
-        /// If value is <see cref="System.Threading.Timeout.InfiniteTimeSpan"/>, latest available value will be provided without waiting (unless no latest value available).</param>
-        public AsyncValueSource(TimeSpan? gracePeriod = default)
-        {
-            if (gracePeriod.HasValue &&
-                gracePeriod <= TimeSpan.Zero &&
-                gracePeriod != Timeout.InfiniteTimeSpan)
-            {
-                throw new ArgumentException($"{nameof(gracePeriod)} must be positive or System.Threading.Timeout.InfiniteTimeSpan", nameof(gracePeriod));
-            }
-            _gracePeriod = gracePeriod;
-        }
-
         public void SetNext(T value)
         {
-            _captured = new AsyncValue<T>(_tcs, DateTime.UtcNow);
+            var captured = _tcs;
             _tcs = new TaskCompletionSource<T>(
                 TaskCreationOptions.RunContinuationsAsynchronously);
-            _captured.TaskCompletionSource.SetResult(value);
+            captured.SetResult(value);
         }
 
-        public Task<T> GetNextAsync()
-        {
-            var captured = _captured;
-            if (_gracePeriod.HasValue && captured != default)
-            {
-                if (_gracePeriod == Timeout.InfiniteTimeSpan ||
-                    captured.ValueTime + _gracePeriod.Value > DateTime.UtcNow)
-                {
-                    return captured.TaskCompletionSource.Task ?? _tcs.Task;
-                }
-                else
-                {
-                    _captured = default;
-                }
-            }
-
-            return _tcs.Task;
-        }
+        public Task<T> GetLatestWithGraceOrNextAsync() => _tcs.Task;
     }
 }

--- a/Bsii.Dotnet.Utils/AsyncValueSource.cs
+++ b/Bsii.Dotnet.Utils/AsyncValueSource.cs
@@ -40,7 +40,7 @@ namespace Bsii.Dotnet.Utils
                 gracePeriod <= TimeSpan.Zero &&
                 gracePeriod != Timeout.InfiniteTimeSpan)
             {
-                throw new ArgumentException("gracePeriod must be positive or System.Threading.Timeout.InfiniteTimeSpan", nameof(gracePeriod));
+                throw new ArgumentException($"{nameof(gracePeriod)} must be positive or System.Threading.Timeout.InfiniteTimeSpan", nameof(gracePeriod));
             }
             _gracePeriod = gracePeriod;
         }
@@ -55,12 +55,13 @@ namespace Bsii.Dotnet.Utils
 
         public Task<T> GetNextAsync()
         {
-            if (_gracePeriod.HasValue && _captured != default)
+            var captured = _captured;
+            if (_gracePeriod.HasValue && captured != default)
             {
                 if (_gracePeriod == Timeout.InfiniteTimeSpan ||
-                    _captured?.ValueTime + _gracePeriod.Value > DateTime.UtcNow)
+                    captured.ValueTime + _gracePeriod.Value > DateTime.UtcNow)
                 {
-                    return _captured?.TaskCompletionSource.Task ?? _tcs.Task;
+                    return captured.TaskCompletionSource.Task ?? _tcs.Task;
                 }
                 else
                 {

--- a/Bsii.Dotnet.Utils/GracefulAsyncEventSource.cs
+++ b/Bsii.Dotnet.Utils/GracefulAsyncEventSource.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Bsii.Dotnet.Utils
+{
+    /// <summary>
+    /// Provides synchronization point for multiple awaiters on a single event source
+    /// </summary>
+    public class GracefulAsyncEventSource
+    {
+        private readonly GracefulAsyncValueSource<bool> _signaler;
+
+        /// <summary>
+        /// </summary>
+        /// <param name="gracePeriod">If null, will block awaiters until next signal,</br>
+        /// If positive, will return to awaiters if latest signal was set for so long since received,</br>
+        /// If value is <see cref="System.Threading.Timeout.InfiniteTimeSpan">, will return without waiting (unless no signal was set).</param>
+        public GracefulAsyncEventSource(TimeSpan? gracePeriod = default)
+            => _signaler = new GracefulAsyncValueSource<bool>(gracePeriod);
+
+        /// <summary>
+        /// Sends a signal to current awaiters
+        /// </summary>
+        public void Signal() => _signaler.SetNext(true);
+
+        /// <summary>
+        /// Waits for a future signal
+        /// </summary>
+        public Task LatestWithGraceOrWaitAsync() => _signaler.GetLatestWithGraceOrNextAsync();
+    }
+}

--- a/Bsii.Dotnet.Utils/GracefulAsyncValueSource.cs
+++ b/Bsii.Dotnet.Utils/GracefulAsyncValueSource.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Bsii.Dotnet.Utils
+{
+    /// <summary>
+    /// Provides <typeparamref name="T"/> values to all asynchronously awaiting consumers<br/>
+    /// Note: all awaiters will get a reference to the same values (in case that <typeparamref name="T"/> is reference type)
+    /// </summary>
+    public class GracefulAsyncValueSource<T> : IAsyncValueProvider<T>
+    {
+        private class TaskCompletionSourceWithTime<TValue> : TaskCompletionSource<TValue>
+        {
+            public DateTime ValueTime { get; set; }
+
+            public TaskCompletionSourceWithTime(DateTime valueTime, TaskCreationOptions taskCreationOptions)
+                : base(taskCreationOptions)
+            {
+                ValueTime = valueTime;
+            }
+        }
+
+        private TaskCompletionSourceWithTime<T> _current = new TaskCompletionSourceWithTime<T>(
+            DateTime.MinValue, TaskCreationOptions.RunContinuationsAsynchronously);
+
+        private TaskCompletionSourceWithTime<T> _captured = new TaskCompletionSourceWithTime<T>(
+            DateTime.MinValue, TaskCreationOptions.RunContinuationsAsynchronously);
+
+        private readonly TimeSpan? _gracePeriod;
+
+        /// <summary>
+        /// </summary>
+        /// <param name="gracePeriod">If null, will block awaiters until next value provided,</br>
+        /// If positive, latest value will be provided to awaiters for so long since received,</br>
+        /// If value is <see cref="System.Threading.Timeout.InfiniteTimeSpan"/>, latest available value will be provided without waiting (unless no latest value available).</param>
+        public GracefulAsyncValueSource(TimeSpan? gracePeriod = default)
+        {
+            if (gracePeriod.HasValue &&
+                gracePeriod <= TimeSpan.Zero &&
+                gracePeriod != Timeout.InfiniteTimeSpan)
+            {
+                throw new ArgumentException($"{nameof(gracePeriod)} must be positive or System.Threading.Timeout.InfiniteTimeSpan", nameof(gracePeriod));
+            }
+            _gracePeriod = gracePeriod;
+        }
+
+        public void SetNext(T value)
+        {
+            _captured = _current;
+            _current = new TaskCompletionSourceWithTime<T>(DateTime.UtcNow,
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            _captured.SetResult(value);
+        }
+
+        public Task<T> GetLatestWithGraceOrNextAsync()
+        {
+            var captured = _captured;
+            if (_gracePeriod.HasValue && captured != default)
+            {
+                if (_gracePeriod == Timeout.InfiniteTimeSpan ||
+                    captured.ValueTime + _gracePeriod.Value > DateTime.UtcNow)
+                {
+                    return captured.Task ?? _current.Task;
+                }
+            }
+
+            return _current.Task;
+        }
+    }
+}

--- a/Bsii.Dotnet.Utils/IAsyncValueProvider.cs
+++ b/Bsii.Dotnet.Utils/IAsyncValueProvider.cs
@@ -4,6 +4,6 @@ namespace Bsii.Dotnet.Utils
 {
     public interface IAsyncValueProvider<T>
     {
-        Task<T> GetNextAsync();
+        Task<T> GetLatestWithGraceOrNextAsync();
     }
 }


### PR DESCRIPTION
For cases when a listener starts waiting for a value just a moment after it was last provided and is fine with that.